### PR TITLE
Feature/opt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 [dependencies]
 ff = {package="ff_ce" , version="0.11", features = ["derive"]}
 rand = "0.4"
+rand6 = {package="rand", version="0.6.5"}
 num = "0.2.0"
 num-bigint = {version = "0.2.2", features = ["rand"]}
 num-traits = "0.2.8"
@@ -19,7 +20,7 @@ generic-array = "0.13.2"
 tiny-keccak = "1.5"
 rustc-hex = "1.0.0"
 mimc-rs = "0.0.2"
-poseidon-rs = "0.0.1"
+poseidon-rs = "0.0.3"
 arrayref = "0.3.5"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,11 @@ repository = "https://github.com/arnaucube/babyjubjub-rs"
 readme = "README.md"
 
 [dependencies]
+ff = {package="ff_ce" , version="0.11", features = ["derive"]}
+rand = "0.4"
 num = "0.2.0"
 num-bigint = {version = "0.2.2", features = ["rand"]}
 num-traits = "0.2.8"
-rand = "0.6.5"
 blake2 = "0.8"
 generic-array = "0.13.2"
 tiny-keccak = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,11 @@ mimc-rs = "0.0.2"
 poseidon-rs = "0.0.1"
 arrayref = "0.3.5"
 lazy_static = "1.4.0"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "bench_babyjubjub"
+harness = false
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # babyjubjub-rs [![Crates.io](https://img.shields.io/crates/v/babyjubjub-rs.svg)](https://crates.io/crates/babyjubjub-rs) [![Build Status](https://travis-ci.org/arnaucube/babyjubjub-rs.svg?branch=master)](https://travis-ci.org/arnaucube/babyjubjub-rs)
-BabyJubJub elliptic curve implementation in Rust. A twisted edwards curve embedded in the curve of BN128.
+BabyJubJub elliptic curve implementation in Rust. A twisted edwards curve embedded in the curve of BN128/BN256.
 
 BabyJubJub curve explanation: https://medium.com/zokrates/efficient-ecc-in-zksnarks-using-zokrates-bd9ae37b8186
 
 Uses:
-- MiMC7 hash function: https://github.com/arnaucube/mimc-rs
 - Poseidon hash function https://github.com/arnaucube/poseidon-rs
 
-Compatible with the BabyJubJub Go implementation from https://github.com/iden3/go-iden3-crypto
+Compatible with the BabyJubJub implementations in:
+- Go, from https://github.com/iden3/go-iden3-crypto
+- circom & javascript, from https://github.com/iden3/circomlib
 
 ## Warning
 Doing this in my free time to get familiar with Rust, **do not use in production**.

--- a/benches/bench_babyjubjub.rs
+++ b/benches/bench_babyjubjub.rs
@@ -1,41 +1,42 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
+extern crate rand;
+#[macro_use]
+extern crate ff;
+use ff::*;
+
 extern crate num;
 extern crate num_bigint;
-extern crate num_traits;
-use num_bigint::{BigInt, ToBigInt};
+use num_bigint::BigInt;
 
 use babyjubjub_rs::{utils, Point};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let x: BigInt = BigInt::parse_bytes(
-        b"17777552123799933955779906779655732241715742912184938656739573121738514868268",
-        10,
-    )
-    .unwrap();
-    c.bench_function("modulus", |b| {
-        b.iter(|| utils::modulus(&x, &babyjubjub_rs::Q))
-    });
+    // let x: BigInt = BigInt::parse_bytes(
+    //     b"17777552123799933955779906779655732241715742912184938656739573121738514868268",
+    //     10,
+    // )
+    // .unwrap();
+    // c.bench_function("modulus", |b| {
+    //     b.iter(|| utils::modulus(&x, &babyjubjub_rs::Q))
+    // });
 
     let p: Point = Point {
-        x: BigInt::parse_bytes(
-            b"17777552123799933955779906779655732241715742912184938656739573121738514868268",
-            10,
+        x: babyjubjub_rs::Fr::from_str(
+            "17777552123799933955779906779655732241715742912184938656739573121738514868268",
         )
         .unwrap(),
-        y: BigInt::parse_bytes(
-            b"2626589144620713026669568689430873010625803728049924121243784502389097019475",
-            10,
+        y: babyjubjub_rs::Fr::from_str(
+            "2626589144620713026669568689430873010625803728049924121243784502389097019475",
         )
         .unwrap(),
+        z: babyjubjub_rs::Fr::one(),
     };
     let q = p.clone();
 
     c.bench_function("add", |b| b.iter(|| p.add(&q)));
-
-    c.bench_function("mul_scalar_small", |b| {
-        b.iter(|| p.mul_scalar(&3.to_bigint().unwrap()))
-    });
+    let r: BigInt = BigInt::parse_bytes(b"3", 10).unwrap();
+    c.bench_function("mul_scalar_small", |b| b.iter(|| p.mul_scalar(&r)));
     let r: BigInt = BigInt::parse_bytes(
         b"2626589144620713026669568689430873010625803728049924121243784502389097019475",
         10,
@@ -43,16 +44,22 @@ fn criterion_benchmark(c: &mut Criterion) {
     .unwrap();
     c.bench_function("mul_scalar", |b| b.iter(|| p.mul_scalar(&r)));
 
-    let sk = babyjubjub_rs::new_key();
-    let pk = sk.public().unwrap();
-    let msg = 5.to_bigint().unwrap();
-    c.bench_function("sign_poseidon", |b| {
-        b.iter(|| sk.sign_poseidon(msg.clone()))
-    });
-    let sig = sk.sign_poseidon(msg.clone()).unwrap();
-    c.bench_function("verify_poseidon", |b| {
-        b.iter(|| babyjubjub_rs::verify_poseidon(pk.clone(), sig.clone(), msg.clone()))
-    });
+    // c.bench_function("compress", |b| b.iter(|| p.compress()));
+    // let p_comp = p.compress();
+    // c.bench_function("decompress", |b| {
+    //     b.iter(|| babyjubjub_rs::decompress_point(p_comp))
+    // });
+
+    // let sk = babyjubjub_rs::new_key();
+    // let pk = sk.public().unwrap();
+    // let msg = 5.to_bigint().unwrap();
+    // c.bench_function("sign_poseidon", |b| {
+    //     b.iter(|| sk.sign_poseidon(msg.clone()))
+    // });
+    // let sig = sk.sign_poseidon(msg.clone()).unwrap();
+    // c.bench_function("verify_poseidon", |b| {
+    //     b.iter(|| babyjubjub_rs::verify_poseidon(pk.clone(), sig.clone(), msg.clone()))
+    // });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/bench_babyjubjub.rs
+++ b/benches/bench_babyjubjub.rs
@@ -7,20 +7,11 @@ use ff::*;
 
 extern crate num;
 extern crate num_bigint;
-use num_bigint::BigInt;
+use num_bigint::{BigInt, ToBigInt};
 
 use babyjubjub_rs::{utils, Point};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    // let x: BigInt = BigInt::parse_bytes(
-    //     b"17777552123799933955779906779655732241715742912184938656739573121738514868268",
-    //     10,
-    // )
-    // .unwrap();
-    // c.bench_function("modulus", |b| {
-    //     b.iter(|| utils::modulus(&x, &babyjubjub_rs::Q))
-    // });
-
     let p: Point = Point {
         x: babyjubjub_rs::Fr::from_str(
             "17777552123799933955779906779655732241715742912184938656739573121738514868268",
@@ -30,11 +21,13 @@ fn criterion_benchmark(c: &mut Criterion) {
             "2626589144620713026669568689430873010625803728049924121243784502389097019475",
         )
         .unwrap(),
-        z: babyjubjub_rs::Fr::one(),
     };
     let q = p.clone();
 
-    c.bench_function("add", |b| b.iter(|| p.add(&q)));
+    let p_projective = p.projective();
+    let q_projective = q.projective();
+
+    c.bench_function("add", |b| b.iter(|| p_projective.add(&q_projective)));
     let r: BigInt = BigInt::parse_bytes(b"3", 10).unwrap();
     c.bench_function("mul_scalar_small", |b| b.iter(|| p.mul_scalar(&r)));
     let r: BigInt = BigInt::parse_bytes(
@@ -44,22 +37,22 @@ fn criterion_benchmark(c: &mut Criterion) {
     .unwrap();
     c.bench_function("mul_scalar", |b| b.iter(|| p.mul_scalar(&r)));
 
-    // c.bench_function("compress", |b| b.iter(|| p.compress()));
-    // let p_comp = p.compress();
-    // c.bench_function("decompress", |b| {
-    //     b.iter(|| babyjubjub_rs::decompress_point(p_comp))
-    // });
+    c.bench_function("point compress", |b| b.iter(|| p.compress()));
+    let p_comp = p.compress();
+    c.bench_function("point decompress", |b| {
+        b.iter(|| babyjubjub_rs::decompress_point(p_comp))
+    });
 
-    // let sk = babyjubjub_rs::new_key();
-    // let pk = sk.public().unwrap();
-    // let msg = 5.to_bigint().unwrap();
-    // c.bench_function("sign_poseidon", |b| {
-    //     b.iter(|| sk.sign_poseidon(msg.clone()))
-    // });
-    // let sig = sk.sign_poseidon(msg.clone()).unwrap();
-    // c.bench_function("verify_poseidon", |b| {
-    //     b.iter(|| babyjubjub_rs::verify_poseidon(pk.clone(), sig.clone(), msg.clone()))
-    // });
+    let sk = babyjubjub_rs::new_key();
+    let pk = sk.public().unwrap();
+    let msg = 5.to_bigint().unwrap();
+    c.bench_function("sign_poseidon", |b| {
+        b.iter(|| sk.sign_poseidon(msg.clone()))
+    });
+    let sig = sk.sign_poseidon(msg.clone()).unwrap();
+    c.bench_function("verify_poseidon", |b| {
+        b.iter(|| babyjubjub_rs::verify_poseidon(pk.clone(), sig.clone(), msg.clone()))
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/bench_babyjubjub.rs
+++ b/benches/bench_babyjubjub.rs
@@ -46,12 +46,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     let sk = babyjubjub_rs::new_key();
     let pk = sk.public().unwrap();
     let msg = 5.to_bigint().unwrap();
-    c.bench_function("sign_poseidon", |b| {
-        b.iter(|| sk.sign_poseidon(msg.clone()))
-    });
-    let sig = sk.sign_poseidon(msg.clone()).unwrap();
-    c.bench_function("verify_poseidon", |b| {
-        b.iter(|| babyjubjub_rs::verify_poseidon(pk.clone(), sig.clone(), msg.clone()))
+    c.bench_function("sign", |b| b.iter(|| sk.sign(msg.clone())));
+    let sig = sk.sign(msg.clone()).unwrap();
+    c.bench_function("verify", |b| {
+        b.iter(|| babyjubjub_rs::verify(pk.clone(), sig.clone(), msg.clone()))
     });
 }
 

--- a/benches/bench_babyjubjub.rs
+++ b/benches/bench_babyjubjub.rs
@@ -1,0 +1,59 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+extern crate num;
+extern crate num_bigint;
+extern crate num_traits;
+use num_bigint::{BigInt, ToBigInt};
+
+use babyjubjub_rs::{utils, Point};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let x: BigInt = BigInt::parse_bytes(
+        b"17777552123799933955779906779655732241715742912184938656739573121738514868268",
+        10,
+    )
+    .unwrap();
+    c.bench_function("modulus", |b| {
+        b.iter(|| utils::modulus(&x, &babyjubjub_rs::Q))
+    });
+
+    let p: Point = Point {
+        x: BigInt::parse_bytes(
+            b"17777552123799933955779906779655732241715742912184938656739573121738514868268",
+            10,
+        )
+        .unwrap(),
+        y: BigInt::parse_bytes(
+            b"2626589144620713026669568689430873010625803728049924121243784502389097019475",
+            10,
+        )
+        .unwrap(),
+    };
+    let q = p.clone();
+
+    c.bench_function("add", |b| b.iter(|| p.add(&q)));
+
+    c.bench_function("mul_scalar_small", |b| {
+        b.iter(|| p.mul_scalar(&3.to_bigint().unwrap()))
+    });
+    let r: BigInt = BigInt::parse_bytes(
+        b"2626589144620713026669568689430873010625803728049924121243784502389097019475",
+        10,
+    )
+    .unwrap();
+    c.bench_function("mul_scalar", |b| b.iter(|| p.mul_scalar(&r)));
+
+    let sk = babyjubjub_rs::new_key();
+    let pk = sk.public().unwrap();
+    let msg = 5.to_bigint().unwrap();
+    c.bench_function("sign_poseidon", |b| {
+        b.iter(|| sk.sign_poseidon(msg.clone()))
+    });
+    let sig = sk.sign_poseidon(msg.clone()).unwrap();
+    c.bench_function("verify_poseidon", |b| {
+        b.iter(|| babyjubjub_rs::verify_poseidon(pk.clone(), sig.clone(), msg.clone()))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use num_traits::{One, Zero};
 
 use generic_array::GenericArray;
 
-mod utils;
+pub mod utils;
 
 #[macro_use]
 extern crate lazy_static;
@@ -25,7 +25,7 @@ extern crate lazy_static;
 lazy_static! {
     static ref D: BigInt = BigInt::parse_bytes(b"168696", 10).unwrap();
     static ref A: BigInt = BigInt::parse_bytes(b"168700", 10).unwrap();
-    static ref Q: BigInt = BigInt::parse_bytes(
+    pub static ref Q: BigInt = BigInt::parse_bytes(
         b"21888242871839275222246405745257275088548364400416034343698204186575808495617",
         10,
     )
@@ -156,6 +156,7 @@ pub fn decompress_point(bb: [u8; 32]) -> Result<Point, String> {
     Ok(Point { x: x, y: y })
 }
 
+#[derive(Debug, Clone)]
 pub struct Signature {
     r_b8: Point,
     s: BigInt,
@@ -497,25 +498,25 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_new_key_sign_verify_mimc_0() {
-        let sk = new_key();
-        let pk = sk.public().unwrap();
-        let msg = 5.to_bigint().unwrap();
-        let sig = sk.sign_mimc(msg.clone()).unwrap();
-        let v = verify_mimc(pk, sig, msg);
-        assert_eq!(v, true);
-    }
-
-    #[test]
-    fn test_new_key_sign_verify_mimc_1() {
-        let sk = new_key();
-        let pk = sk.public().unwrap();
-        let msg = BigInt::parse_bytes(b"123456789012345678901234567890", 10).unwrap();
-        let sig = sk.sign_mimc(msg.clone()).unwrap();
-        let v = verify_mimc(pk, sig, msg);
-        assert_eq!(v, true);
-    }
+    // #[test]
+    // fn test_new_key_sign_verify_mimc_0() {
+    //     let sk = new_key();
+    //     let pk = sk.public().unwrap();
+    //     let msg = 5.to_bigint().unwrap();
+    //     let sig = sk.sign_mimc(msg.clone()).unwrap();
+    //     let v = verify_mimc(pk, sig, msg);
+    //     assert_eq!(v, true);
+    // }
+    //
+    // #[test]
+    // fn test_new_key_sign_verify_mimc_1() {
+    //     let sk = new_key();
+    //     let pk = sk.public().unwrap();
+    //     let msg = BigInt::parse_bytes(b"123456789012345678901234567890", 10).unwrap();
+    //     let sig = sk.sign_mimc(msg.clone()).unwrap();
+    //     let v = verify_mimc(pk, sig, msg);
+    //     assert_eq!(v, true);
+    // }
     #[test]
     fn test_new_key_sign_verify_poseidon_0() {
         let sk = new_key();
@@ -596,50 +597,50 @@ mod tests {
         assert_eq!(&p.x, &expected_px);
     }
 
-    #[test]
-    fn test_point_decompress_loop() {
-        for _ in 0..5 {
-            let mut rng = rand::thread_rng();
-            let sk_raw = rng.gen_biguint(1024).to_bigint().unwrap();
-            let mut hasher = Blake2b::new();
-            let (_, sk_raw_bytes) = sk_raw.to_bytes_be();
-            hasher.input(sk_raw_bytes);
-            let mut h = hasher.result();
+    // #[test]
+    // fn test_point_decompress_loop() {
+    //     for _ in 0..5 {
+    //         let mut rng = rand::thread_rng();
+    //         let sk_raw = rng.gen_biguint(1024).to_bigint().unwrap();
+    //         let mut hasher = Blake2b::new();
+    //         let (_, sk_raw_bytes) = sk_raw.to_bytes_be();
+    //         hasher.input(sk_raw_bytes);
+    //         let mut h = hasher.result();
+    //
+    //         h[0] = h[0] & 0xF8;
+    //         h[31] = h[31] & 0x7F;
+    //         h[31] = h[31] | 0x40;
+    //
+    //         let sk = BigInt::from_bytes_le(Sign::Plus, &h[..]);
+    //         let point = B8.mul_scalar(&sk).unwrap();
+    //         let cmp_point = point.compress();
+    //         let dcmp_point = decompress_point(cmp_point).unwrap();
+    //
+    //         assert_eq!(&point.x, &dcmp_point.x);
+    //         assert_eq!(&point.y, &dcmp_point.y);
+    //     }
+    // }
 
-            h[0] = h[0] & 0xF8;
-            h[31] = h[31] & 0x7F;
-            h[31] = h[31] | 0x40;
-
-            let sk = BigInt::from_bytes_le(Sign::Plus, &h[..]);
-            let point = B8.mul_scalar(&sk).unwrap();
-            let cmp_point = point.compress();
-            let dcmp_point = decompress_point(cmp_point).unwrap();
-
-            assert_eq!(&point.x, &dcmp_point.x);
-            assert_eq!(&point.y, &dcmp_point.y);
-        }
-    }
-
-    #[test]
-    fn test_signature_compress_decompress() {
-        let sk = new_key();
-        let pk = sk.public().unwrap();
-
-        for i in 0..5 {
-            let msg_raw = "123456".to_owned() + &i.to_string();
-            let msg = BigInt::parse_bytes(msg_raw.as_bytes(), 10).unwrap();
-            let sig = sk.sign_mimc(msg.clone()).unwrap();
-
-            let compressed_sig = sig.compress();
-            let decompressed_sig = decompress_signature(&compressed_sig).unwrap();
-            assert_eq!(&sig.r_b8.x, &decompressed_sig.r_b8.x);
-            assert_eq!(&sig.r_b8.y, &decompressed_sig.r_b8.y);
-            assert_eq!(&sig.s, &decompressed_sig.s);
-
-            let v = verify_mimc(pk.clone(), decompressed_sig, msg);
-            assert_eq!(v, true);
-        }
-    }
+    // #[test]
+    // fn test_signature_compress_decompress() {
+    //     let sk = new_key();
+    //     let pk = sk.public().unwrap();
+    //
+    //     for i in 0..5 {
+    //         let msg_raw = "123456".to_owned() + &i.to_string();
+    //         let msg = BigInt::parse_bytes(msg_raw.as_bytes(), 10).unwrap();
+    //         let sig = sk.sign_mimc(msg.clone()).unwrap();
+    //
+    //         let compressed_sig = sig.compress();
+    //         let decompressed_sig = decompress_signature(&compressed_sig).unwrap();
+    //         assert_eq!(&sig.r_b8.x, &decompressed_sig.r_b8.x);
+    //         assert_eq!(&sig.r_b8.y, &decompressed_sig.r_b8.y);
+    //         assert_eq!(&sig.s, &decompressed_sig.s);
+    //
+    //         let v = verify_mimc(pk.clone(), decompressed_sig, msg);
+    //         assert_eq!(v, true);
+    //     }
+    // }
 
     #[test]
     fn test_schnorr_signature() {


### PR DESCRIPTION
Add [ff](https://github.com/matter-labs/ff) for internal finite field operations, and add `add-2008-bbjlp` for point addition.

Benchmarks (On a Intel(R) Core(TM) i7-8705G CPU @ 3.10GHz, with 32 GB of RAM):
```
- before:
add               time:   [53.447 us 53.467 us 53.492 us]
mul_scalar        time:   [121.19 ms 121.22 ms 121.25 ms]
sign              time:   [383.01 ms 384.46 ms 385.98 ms]
verify            time:   [250.56 ms 251.46 ms 252.43 ms]

- current:
add               time:   [317.34 ns 317.44 ns 317.54 ns]
mul_scalar        time:   [131.05 us 131.28 us 131.58 us]
sign              time:   [973.38 us 973.83 us 974.41 us]
verify            time:   [835.34 us 839.94 us 845.29 us]
```

add: `168x` improvement
mul_scalar: `923x` improvement
sign: `394x` improvement
verify: `300x` improvement

Still needs a refactor.