### PR TITLE
Update EdDSA to last circomlib version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rand6 = {package="rand", version="0.6.5"}
 num = "0.2.0"
 num-bigint = {version = "0.2.2", features = ["rand"]}
 num-traits = "0.2.8"
-blake2 = "0.8"
+blake-hash = "0.4.0"
 generic-array = "0.13.2"
 tiny-keccak = "1.5"
 rustc-hex = "1.0.0"


### PR DESCRIPTION
- Update EdDSA to last circomlib version
	- Compatible with circomlib version 0.3.0 at
	  https://github.com/iden3/circomlib/commit/5935ac69df760437da84cc7fe9f4db3ead56d47b
	- Use blake hash precandidate (non-blake2b) for circomlib
	  compatibility
	- Add circomlib testvector
- Change PrivateKey from BigInt to [u8;32], which lead to faster
signature computation:
	(Benchmarks on a Intel(R) Core(TM) i7-8705G CPU @ 3.10GHz, with
	32 GB of RAM)
	- Old:
	    ```
	    sign                    time:   [559.84 us 568.41 us 576.26 us]
	    verify                  time:   [376.59 us 376.68 us 376.78 us]
	    ```
	- New:
	    ```
	    sign                    time:   [383.85 us 390.31 us 396.44 us]
	    verify                  time:   [371.33 us 376.06 us 381.19 us]
	    ```