### PR TITLE
Update rust to 2021 and deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,30 @@
 [package]
 name = "babyjubjub-rs"
-version = "0.0.8"
+version = "0.0.9"
 authors = ["arnaucube <root@arnaucube.com>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 description = "BabyJubJub elliptic curve implementation"
 repository = "https://github.com/arnaucube/babyjubjub-rs"
 readme = "README.md"
 
 [dependencies]
-ff = {package="ff_ce" , version="0.11", features = ["derive"]}
-rand = "0.4"
-rand6 = {package="rand", version="0.6.5"}
-num = "0.2.0"
-num-bigint = {version = "0.2.2", features = ["rand"]}
+ff = {package="ff_ce" , version= "0.11", features = ["derive"]}
+rand = "0.8"
+num = "0.4"
+num-bigint = {version = "0.4", features = ["rand"]}
 num-traits = "0.2.8"
 blake-hash = {version="0.4.0", optional=true}
 blake = {version="2.0.1", optional=true}
-generic-array = "0.13.2"
-tiny-keccak = "1.5"
-rustc-hex = "1.0.0"
+generic-array = "0.14"
 poseidon-rs = "0.0.8"
 arrayref = "0.3.5"
 lazy_static = "1.4.0"
 
 [dev-dependencies]
 criterion = "0.3"
+hex = "0.4"
+
 
 [[bench]]
 name = "bench_babyjubjub"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,6 @@
 // BabyJubJub elliptic curve implementation in Rust.
 // For LICENSE check https://github.com/arnaucube/babyjubjub-rs
 
-extern crate num;
-extern crate num_bigint;
-extern crate num_traits;
-
 use num_bigint::{BigInt, ToBigInt};
 use num_traits::{One, Zero};
 


### PR DESCRIPTION
@arnaucube Thanks for this project!

This PR:
 *  update rust to edition 2021
 *  update some dependencies
 * replace `rustc-hex` by `hex`

