### PR TITLE
Added features and a bug fix from https://github.com/arnaucube/babyjubjub-rs/issues/7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 
 [dependencies]
 ff = {package="ff_ce", version= "0.11", features = ["derive"]}
-rand = "0.8"
+rand_new = {package="rand", version="0.8"}
+rand = "0.4.6"
 num = "0.4"
 num-bigint = {version = "0.4", features = ["rand"]}
 num-traits = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ readme = "README.md"
 ff = {package="ff_ce", version= "0.11", features = ["derive"]}
 rand_new = {package="rand", version="0.8.5"}
 rand = "0.4.6"
+# rand = "0.8"
 num = "0.4"
 num-bigint = {version = "0.4", features = ["rand"]}
 num-traits = "0.2.8"
-blake2 = "0.10.6"
-# blake-hash = {version="0.4.0", optional=true}
-# blake = {version="2.0.1", optional=true}
+# blake2 = "0.10.6"
+blake-hash = {version="0.4.0", optional=true}
+blake = {version="2.0.1", optional=true}
 generic-array = "0.14"
 poseidon-rs = "0.0.8"
 arrayref = "0.3.5"
@@ -34,6 +35,6 @@ hex = "0.4"
 name = "bench_babyjubjub"
 harness = false
 
-# [features]
-# default = ["blake-hash"]
-# aarch64 = ["blake"]
+[features]
+default = ["blake-hash"]
+aarch64 = ["blake"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,8 @@ rand_new = {package="rand", version="0.8.5"}
 rand = "0.4.6"
 # rand = "0.8"
 num = "0.4"
-num-bigint = {version = "0.4", features = ["rand"]}
+num-bigint = {version = "0.4", features = ["rand", "serde"]}
 num-traits = "0.2.8"
-# blake2 = "0.10.6"
 blake-hash = {version="0.4.0", optional=true}
 blake = {version="2.0.1", optional=true}
 generic-array = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ generic-array = "0.14"
 poseidon-rs = "0.0.8"
 arrayref = "0.3.5"
 lazy_static = "1.4.0"
+serde = { version = "1.0.152", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ rand = "0.8"
 num = "0.4"
 num-bigint = {version = "0.4", features = ["rand"]}
 num-traits = "0.2.8"
-blake-hash = {version="0.4.0", optional=true}
-blake = {version="2.0.1", optional=true}
+blake2 = "0.10.6"
+# blake-hash = {version="0.4.0", optional=true}
+# blake = {version="2.0.1", optional=true}
 generic-array = "0.14"
 poseidon-rs = "0.0.8"
 arrayref = "0.3.5"
@@ -30,6 +31,6 @@ hex = "0.4"
 name = "bench_babyjubjub"
 harness = false
 
-[features]
-default = ["blake-hash"]
-aarch64 = ["blake"]
+# [features]
+# default = ["blake-hash"]
+# aarch64 = ["blake"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ arrayref = "0.3.5"
 lazy_static = "1.4.0"
 serde = { version = "1.0.152", features = ["derive"] }
 bytes = "1.4.0"
-rust-gmp = "0.5.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ rand = "0.4.6"
 num = "0.4"
 num-bigint = {version = "0.4", features = ["rand", "serde"]}
 num-traits = "0.2.8"
-blake-hash = {version="0.4.0", optional=true}
-blake = {version="2.0.1", optional=true}
 generic-array = "0.14"
 poseidon-rs = "0.0.8"
 arrayref = "0.3.5"
@@ -34,6 +32,15 @@ hex = "0.4"
 name = "bench_babyjubjub"
 harness = false
 
-[features]
-default = ["blake-hash"]
-aarch64 = ["blake"]
+[target.'cfg(not(any( target_arch = "aarch64", target_arch = "wasm32" )))'.dependencies]
+blake-hash = {version="0.4.1" }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+blake = { version = "2.0.1" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+blake2 = { version = "0.10.6" }
+
+# [features]
+# default = ["blake-hash"]
+# aarch64 = ["blake"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/arnaucube/babyjubjub-rs"
 readme = "README.md"
 
 [dependencies]
-ff = {package="ff_ce" , version= "0.11", features = ["derive"]}
+ff = {package="ff_ce", version= "0.11", features = ["derive"]}
 rand = "0.8"
 num = "0.4"
 num-bigint = {version = "0.4", features = ["rand"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 ff = {package="ff_ce", version= "0.11", features = ["derive"]}
-rand_new = {package="rand", version="0.8"}
+rand_new = {package="rand", version="0.8.5"}
 rand = "0.4.6"
 num = "0.4"
 num-bigint = {version = "0.4", features = ["rand"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ poseidon-rs = "0.0.8"
 arrayref = "0.3.5"
 lazy_static = "1.4.0"
 serde = { version = "1.0.152", features = ["derive"] }
+bytes = "1.4.0"
+rust-gmp = "0.5.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,6 @@ impl PrivateKey {
 // encrypts msg to public key to_pubkey, using some random scalar nonce
 pub fn encrypt_elgamal(to_pubkey: &Point, nonce: &BigInt, msg: &Point) -> ElGamalEncryption {
     let shared_secret = to_pubkey.mul_scalar(&nonce);
-    println!("Shared Secret 2 {:?}", shared_secret);
     let public_nonce = B8.mul_scalar(&nonce);
     // let msg_point = point_for_msg(msg);
     let msg_plus_secret = msg.projective().add(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 // For LICENSE check https://github.com/arnaucube/babyjubjub-rs
 
 use ff::*;
-use serde::{Serialize, Deserialize, ser::SerializeSeq};
+use serde::{Serialize, ser::SerializeSeq};
 use poseidon_rs::Poseidon;
 pub type Fr = poseidon_rs::Fr; // alias
 
@@ -260,7 +260,7 @@ pub fn blh(b: &[u8]) -> Vec<u8> {
     return digest[..].to_vec();
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Signature {
     pub r_b8: Point,
     pub s: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ impl PrivateKey {
 }
 
 // encrypts msg to public key to_pubkey, using some random scalar nonce
-pub fn encrypt_elgamal(to_pubkey: Point, nonce: BigInt, msg: &Point) -> ElGamalEncryption {
+pub fn encrypt_elgamal(to_pubkey: &Point, nonce: &BigInt, msg: &Point) -> ElGamalEncryption {
     let shared_secret = to_pubkey.mul_scalar(&nonce);
     println!("Shared Secret 2 {:?}", shared_secret);
     let public_nonce = B8.mul_scalar(&nonce);
@@ -529,8 +529,8 @@ mod tests {
         let some_point = B8.mul_scalar(&BigInt::from_u8(0x69).unwrap());
         let some_privkey = new_key();
         let some_point_encrypted = encrypt_elgamal(
-            some_privkey.public(), 
-            BigInt::parse_bytes(b"ABCDEF123456789", 16).unwrap(), 
+            &some_privkey.public(), 
+            &BigInt::parse_bytes(b"ABCDEF123456789", 16).unwrap(), 
             &some_point
         );
         let some_point_encrypted_decrypted = some_privkey.decrypt_elgamal(some_point_encrypted);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,9 +418,7 @@ impl PrivateKey {
     pub fn decrypt_elgamal(&self, encrypted_point: ElGamalEncryption) -> Point {
         // Make sure inputs aren't bad (i imagine this check could be skipped for performance reasons, but it seems a sanity check here would be helpful)
         assert!(encrypted_point.c1.on_curve() && encrypted_point.c2.on_curve());
-
         let shared_secret = encrypted_point.c1.mul_scalar(&self.scalar_key());
-        println!("Shared Secret {:?}", shared_secret);
         // Subtract the shared secret
         encrypted_point.c2.projective().add(
                 &shared_secret.inverse().projective()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,7 +331,7 @@ impl Point {
         r
     }
 
-    pub fn equals(&self, p: Point) -> bool {
+    pub fn equals(&self, p: &Point) -> bool {
         if self.x == p.x && self.y == p.y {
             return true;
         }
@@ -415,7 +415,7 @@ impl Point {
     pub fn in_subgroup(&self) -> bool {
         let should_be_zero = self.mul_scalar(&SUBORDER);
         should_be_zero.equals({
-            Point { x: Fr::zero(), y: Fr::one() }
+            &O
         })
     }
 
@@ -607,7 +607,7 @@ impl PrivateKey {
         Ok((r, s))
     }
 
-    pub fn decrypt_elgamal(&self, encrypted_point: ElGamalEncryption) -> Point {
+    pub fn decrypt_elgamal(&self, encrypted_point: &ElGamalEncryption) -> Point {
         // Make sure inputs aren't bad (i imagine this check could be skipped for performance reasons, but it seems a sanity check here would be helpful)
         assert!(encrypted_point.c1.on_curve(), "Error: C1 is not on the curve!");
         assert!(encrypted_point.c1.in_subgroup(), "Error: C1 is not in the subgroup!");
@@ -654,7 +654,7 @@ pub fn verify_schnorr(pk: Point, m: BigInt, r: Point, s: BigInt) -> Result<bool,
     let pk_h = pk.mul_scalar(&h);
     let right = r.add(&pk_h);
 
-    Ok(sg.equals(right))
+    Ok(sg.equals(&right))
 }
 
 pub fn new_key() -> PrivateKey {
@@ -680,7 +680,7 @@ pub fn verify(pk: Point, sig: Signature, msg: BigInt) -> bool {
     let r = sig
         .r_b8
         .add(&pk.mul_scalar(&(8.to_bigint().unwrap() * hm_b)));
-    l.equals(r)
+    l.equals(&r)
 }
 
 
@@ -856,7 +856,7 @@ mod tests {
         some_point_x_inverse.sub_assign(&some_point.x);
         // assert_eq!(some_point_x_inverse, some_point.x.inverse().unwrap());
         assert!(some_point.equals(
-            some_point.add(&another_point).add(
+            &some_point.add(&another_point).add(
             &another_point.neg())
         ));
 
@@ -870,7 +870,7 @@ mod tests {
             &BigInt::parse_bytes(b"ABCDEF123456789", 16).unwrap(), 
             &some_point
         );
-        let some_point_encrypted_decrypted = some_privkey.decrypt_elgamal(some_point_encrypted);
+        let some_point_encrypted_decrypted = some_privkey.decrypt_elgamal(&some_point_encrypted);
 
         assert_eq!(some_point.x, some_point_encrypted_decrypted.x);
         assert_eq!(some_point.y, some_point_encrypted_decrypted.y);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // For LICENSE check https://github.com/arnaucube/babyjubjub-rs
 
 use ff::*;
+use num::Num;
 use serde::{Serialize, ser::SerializeSeq};
 use bytes::{BytesMut, BufMut};
 use poseidon_rs::Poseidon;
@@ -150,13 +151,24 @@ pub struct Point {
     pub y: Fr,
 }
 
+pub trait ToDecimalString {
+    fn to_dec_string(&self) -> String;
+}
+impl ToDecimalString for Fr {
+    fn to_dec_string(&self) -> String {
+        let mut s = self.to_string();
+        let hex_str = s[5..s.len()-1].to_string();
+        BigInt::from_str_radix(&hex_str, 16).unwrap().to_string()
+    }
+}
+
 impl Serialize for Point {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer {
                 let mut seq = serializer.serialize_seq(Some(2))?;
-                seq.serialize_element(&self.x.to_string())?;
-                seq.serialize_element(&self.y.to_string())?;
+                seq.serialize_element(&self.x.to_dec_string())?;
+                seq.serialize_element(&self.y.to_dec_string())?;
                 seq.end()
     }
 }
@@ -390,7 +402,7 @@ pub fn decompress_signature(b: &[u8; 64]) -> Result<Signature, String> {
         Result::Ok(res) => Ok(Signature { r_b8: res, s: s.to_string() }),
     }
 }
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ElGamalEncryption {
     pub c1: Point,
     pub c2: Point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,7 @@ impl Point {
                 y = numerator.sqrt();
             } else {
                 acc += 1;
+                x.add_assign(&Fr::one());
             }
         }
         // Unwrap y since we can't be 100% sure at compile-time it will have been found; it may still be a None value!
@@ -578,6 +579,22 @@ mod tests {
         assert_eq!(B8.mul_scalar(&12345.to_bigint().unwrap()).on_curve(), true);
         assert_eq!(some_point.on_curve(), false);
     
+    }
+    #[test]
+    fn test_from_msg_vartime() {
+        let MAX_MSG: BigInt = BigInt::parse_bytes(
+            b"2188824287183927522224640574525727508854836440041603434369820418657580849",10 // Prime r but missing last 4 digits
+        ).unwrap();
+
+        let msg = 123456789.to_bigint().unwrap();
+        assert!(Point::from_msg_vartime(msg).on_curve());
+
+        // Try with some more random numbers -- it's extremely unlikely to get lucky will with valid points 20 times in a row if it's not always producing valid points
+        for n in 0..20 {
+            let m = rand::thread_rng().gen_bigint_range(&0.to_bigint().unwrap() , &MAX_MSG);
+            assert!(Point::from_msg_vartime(m).on_curve());
+        }
+
     }
     #[test]
     fn test_neg() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,7 +552,7 @@ pub fn decompress_signature(b: &[u8; 64]) -> Result<Signature, String> {
         Result::Ok(res) => Ok(Signature { r_b8: res, s: s.to_string() }),
     }
 }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ElGamalEncryption {
     pub c1: Point,
     pub c2: Point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,7 @@ pub fn decompress_point(bb: [u8; 32]) -> Result<Point, String> {
 // }
 
 fn blh(b: &[u8]) -> Vec<u8> {
+    println!("TODO: add test that this new blake512 function is giving correct output. Not doing so could have unlikely yet critical implications");
     let mut h = Blake2b512::new();
     h.update(b);
     let digest = h.finalize();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,31 +206,75 @@ impl Point {
         false
     }
 
-    // // Use a variation of the Koblitz method
-    // pub fn from_msg_vartime(msg: &[u8; 28]) -> Point {
-    // }
-
-    pub fn from_msg(msg: &[u8; 28]) -> Point {
+    // Use a variation of the Koblitz method
+    pub fn from_msg_vartime(msg: BigInt/*msg: &[u8; 28]*/) -> Point {
         // This is the largest point that can fit BabyJubJub curve while still allowing 8 extra bytes, as long as those bytes are less than f0000001
         // Babyjubjub r parameter is 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
-        assert!(
-            BigInt::from_bytes_be(Sign::Plus, msg) 
-            < 
-            BigInt::parse_bytes(b"30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",16).unwrap()
-        );
-        let mut acc: u32 = 0;
-        let mut pt: Point;
-        let mut is_residue: bool = false;
+        // assert!(
+        //     BigInt::from_bytes_be(Sign::Plus, msg) 
+        //     < 
+        //     BigInt::parse_bytes(b"30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f00000",16).unwrap()
+        // );
+        // let mut acc: u32 = 0;
+        // let mut pt: Point;
+        // let mut is_residue: bool = false;
+        // let mut on_curve: bool = false;
+        // while (acc <= 0xf0000001) && !on_curve {
+        //     let acc_bytes: [u8; 4] = acc.to_be_bytes();
+        //     // let mut buff: ArrayVec::<[u8; 32]> = concat_bytes!()[msg, acc_bytes]);
+        //     let mut buf = BytesMut::with_capacity(32);
+        //     buf.put_slice(msg);
+        //     buf.put_u32(acc);
+        //     Fr::from_str("123").unwrap().legendre()
+        //     println!("bytes {:?}", buf);
+        // }
+        
+        // Koblitz decoding method, adapted for this curve: 
+        // message m must be < r/10000
+        // Try finding a point with y value m*10000+0, m*10000+1, .... m*10000+5617 (5617 are last four digits of prime r)
+        // There is an approximately 1/(2^1000) chance no point will be encodable,
+        // since each y value has probability of about 1/2 of being on the curve
+        let MAX_MSG: BigInt = BigInt::parse_bytes(
+            b"2188824287183927522224640574525727508854836440041603434369820418657580849",10 // Prime r but missing last 4 digits
+        ).unwrap();
+        let ACC_UNDER = 5617; // Last four digits of prime r. MAX_MSG * 10000 + ACC_UNDER = r
+        assert!(msg <= MAX_MSG);
+        let mut acc: u16 = 0;
         let mut on_curve: bool = false;
-        while (acc <= 0xf0000001) && !on_curve {
-            let acc_bytes: [u8; 4] = acc.to_be_bytes();
-            // let mut buff: ArrayVec::<[u8; 32]> = concat_bytes!()[msg, acc_bytes]);
-            let mut buf = BytesMut::with_capacity(32);
-            buf.put_slice(msg);
-            buf.put_u32(acc);
-            println!("bytes {:?}", buf);
+        // Start with message * 10000 as x coordinate
+        let mut x: Fr = Fr::from_str(&msg.to_str_radix(10)).unwrap();
+        let mut y: Option<Fr> = None; 
+        x.mul_assign(&Fr::from_str("10000").unwrap());
+
+        let one = Fr::one();
+        // let m10000 = 1000.to_bigint().unwrap() * msg;
+        while (acc < ACC_UNDER) && !on_curve {
+            // If x is on curve, calculate what y^2 should be, by (ax^2 - 1) / (dx^2 - 1)
+            let mut x2 = x.clone();
+            x2.mul_assign(&x);
+
+            // Numerator will be (ax^2 - 1) and denominator will be (dx^2 - 1)
+            let mut numerator = x2;
+            let mut denominator = x2.clone();
+
+            numerator.mul_assign(&A);
+            denominator.mul_assign(&D);
+
+            numerator.sub_assign(&one);
+            denominator.sub_assign(&one);
+
+            // If the point is on the curve, numerator/denominator will be y^2. Check whether numerator/denominator is a quadratic residue:
+            numerator.mul_assign(&denominator.inverse().unwrap()); // Note: this is no longer a numerator since it was divided in this step
+            if let LegendreSymbol::QuadraticResidue = numerator.legendre() {
+                on_curve=true;
+                y = numerator.sqrt();
+            } else {
+                acc += 1;
+            }
         }
-        Point {x:Fr::zero(), y:Fr::zero()}
+        // Unwrap y since we can't be 100% sure at compile-time it will have been found; it may still be a None value!
+        Point {x:x, y:y.unwrap()}
+
     }
 
     pub fn on_curve(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ lazy_static! {
     )
         .unwrap()
         >> 3;
-    static ref POSEIDON: poseidon_rs::Poseidon = Poseidon::new();
+    pub static ref POSEIDON: poseidon_rs::Poseidon = Poseidon::new();
 }
 
 #[derive(Clone, Debug)]
@@ -248,6 +248,7 @@ fn blh(b: &[u8]) -> Vec<u8> {
     let digest = h.finalize();
     return digest[..].to_vec();
 }
+
 #[derive(Debug, Clone)]
 pub struct Signature {
     pub r_b8: Point,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ pub fn decompress_point(bb: [u8; 32]) -> Result<Point, String> {
 //     hash.to_vec()
 // }
 
-fn blh(b: &[u8]) -> Vec<u8> {
+pub fn blh(b: &[u8]) -> Vec<u8> {
     println!("TODO: add test that this new blake512 function is giving correct output. Not doing so could have unlikely yet critical implications");
     let mut h = Blake2b512::new();
     h.update(b);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,13 @@ impl Point {
 
         lhs.eq(&rhs)
     }
+
+    pub fn from_xy_strings(x: String, y: String) -> Point {
+        Point {
+            x: Fr::from_str(&x).unwrap(),
+            y: Fr::from_str(&y).unwrap()
+        }
+    }
 }
 
 pub fn test_bit(b: &[u8], i: usize) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,7 @@ pub fn decompress_signature(b: &[u8; 64]) -> Result<Signature, String> {
         Result::Ok(res) => Ok(Signature { r_b8: res, s: s.to_string() }),
     }
 }
-
+#[derive(Debug)]
 pub struct ElGamalEncryption {
     pub c1: Point,
     pub c2: Point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,15 +6,12 @@ use rand::ThreadRng;
 use std::{iter::Sum, ops::{Neg, AddAssign}, fmt::Error};
 use num::Num;
 use std::fmt;
-// use serde::{Serialize, ser::SerializeSeq, Deserialize};
 use serde::{Serialize, ser::SerializeStruct, de::Visitor, de::MapAccess, Deserialize, Deserializer};
-// use bytes::{BytesMut, BufMut};
 use poseidon_rs::Poseidon;
 pub type Fr = poseidon_rs::Fr; // alias
 
 extern crate rand_new;
 extern crate rand;
-// #[macro_use]
 extern crate ff;
 
 // Create a new primefield for the subgroup defined by the base point, order Fl:
@@ -25,13 +22,12 @@ pub struct Fl(FpRepr);
 
 use arrayref::array_ref;
 
-// #[cfg(not(feature = "aarch64"))]
-// use blake_hash::Digest; // compatible version with Blake used at circomlib
+#[cfg(not(feature = "aarch64"))]
+use blake_hash::Digest; // compatible version with Blake used at circomlib
 
-// #[cfg(feature = "aarch64")]
-// extern crate blake; // compatible version with Blake used at circomlib
-use blake2::{Blake2b512, Digest};
-// use hex_literal::hex;
+#[cfg(feature = "aarch64")]
+extern crate blake; // compatible version with Blake used at circomlib
+
 use std::{cmp::min, str::FromStr};
 
 use num_bigint::{BigInt, RandBigInt, Sign, ToBigInt};
@@ -502,29 +498,28 @@ pub fn decompress_point(bb: [u8; 32]) -> Result<Point, String> {
     Ok(Point { x: x_fr, y: y_fr })
 }
 
-// #[cfg(not(feature = "aarch64"))]
-// fn blh(b: &[u8]) -> Vec<u8> {
-//     println!("hashing {:?} {:?}", b.len(), b);
-//     let debugggggggggme = blake_hash::Blake512::digest(b);
-//     println!("debugging {:?}", debugggggggggme);
-
-//     let hash = blake_hash::Blake512::digest(b);
-//     hash.to_vec()
-// }
-
-// #[cfg(feature = "aarch64")]
-// fn blh(b: &[u8]) -> Vec<u8> {
-//     let mut hash = [0; 64];
-//     blake::hash(512, b, &mut hash).unwrap();
-//     hash.to_vec()
-// }
-
-pub fn blh(b: &[u8]) -> Vec<u8> {
-    let mut h = Blake2b512::new();
-    h.update(b);
-    let digest = h.finalize();
-    return digest[..].to_vec();
+#[cfg(not(feature = "aarch64"))]
+fn blh(b: &[u8]) -> Vec<u8> {
+    // println!("hashing {:?} {:?}", b.len(), b);
+    // let debugggggggggme = blake_hash::Blake512::digest(b);
+    // println!("debugging {:?}", debugggggggggme);
+    let hash = blake_hash::Blake512::digest(b);
+    hash.to_vec()
 }
+
+#[cfg(feature = "aarch64")]
+fn blh(b: &[u8]) -> Vec<u8> {
+    let mut hash = [0; 64];
+    blake::hash(512, b, &mut hash).unwrap();
+    hash.to_vec()
+}
+
+// pub fn blh(b: &[u8]) -> Vec<u8> {
+//     let mut h = Blake2b512::new();
+//     h.update(b);
+//     let digest = h.finalize();
+//     return digest[..].to_vec();
+// }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Signature {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use arrayref::array_ref;
 // extern crate blake; // compatible version with Blake used at circomlib
 use blake2::{Blake2b512, Digest};
 // use hex_literal::hex;
-use std::{cmp::min, io::Bytes};
+use std::{cmp::min, io::Bytes, str::FromStr};
 
 use num_bigint::{BigInt, RandBigInt, Sign, ToBigInt};
 use num_traits::One;
@@ -159,6 +159,15 @@ impl ToDecimalString for Fr {
         let mut s = self.to_string();
         let hex_str = s[5..s.len()-1].to_string();
         BigInt::from_str_radix(&hex_str, 16).unwrap().to_string()
+    }
+}
+pub trait FrToBigInt {
+    fn to_bigint(&self) -> BigInt;
+}
+
+impl FrToBigInt for Fr {
+    fn to_bigint(&self) -> BigInt {
+        BigInt::from_str(&self.to_dec_string()).unwrap()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,27 +226,27 @@ impl FrBigIntConversion<Fl> for Fl {
     }
 }
 
-pub struct FrWrapper {
-    pub fr: Fr
-}
-impl FrWrapper {
-    pub fn from_fr(fr: Fr) -> FrWrapper {
-        FrWrapper { fr: fr }
-    }
-}
+// pub struct FrWrapper {
+//     pub fr: Fr
+// }
+// impl FrWrapper {
+//     pub fn from_fr(fr: Fr) -> FrWrapper {
+//         FrWrapper { fr: fr }
+//     }
+// }
 
-impl Sum for FrWrapper {
-    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(
-            |frw1,frw2| {
-                let mut tmp = frw1.fr.clone();
-                tmp.add_assign(&frw2.fr);
-                FrWrapper { fr: tmp }
-            }
+// impl Sum for FrWrapper {
+//     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+//         iter.reduce(
+//             |frw1,frw2| {
+//                 let mut tmp = frw1.fr.clone();
+//                 tmp.add_assign(&frw2.fr);
+//                 FrWrapper { fr: tmp }
+//             }
 
-        ).unwrap()
-    }
-}
+//         ).unwrap()
+//     }
+// }
 
 
 impl Serialize for Point {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,9 @@ impl PrivateKey {
     }
 
     pub fn decrypt_elgamal(&self, encrypted_point: ElGamalEncryption) -> Point {
+        // Make sure inputs aren't bad (i imagine this check could be skipped for performance reasons, but it seems a sanity check here would be helpful)
+        assert!(encrypted_point.c1.on_curve() && encrypted_point.c2.on_curve());
+
         let shared_secret = encrypted_point.c1.mul_scalar(&self.scalar_key());
         println!("Shared Secret {:?}", shared_secret);
         // Subtract the shared secret

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,6 @@ pub trait FrBigIntConversion<T> {
 impl FrBigIntConversion<Fr> for Fr {
     // Note: this could probably be more efficient by converting bigint to raw repr to Fr
     fn from_bigint(bi: &BigInt) -> Fr {
-        println!("bi: {}", bi.to_string());
         Fr::from_str(&bi.to_string()).unwrap()
     }
     fn to_bigint(&self) -> BigInt {
@@ -705,7 +704,6 @@ impl DLEQProof {
         // TODO: better error handling (not assert), make it more efficient too:
         assert!(x_bigint < modulus);
 
-        // println!("modulus overflow? isn't it bigger than Fr's order: {:?}", modulus_overflowed);
         let k_bigint = rand_new::thread_rng().gen_biguint(512).to_bigint().unwrap() % &modulus;
         let k = Fl::from_bigint(&k_bigint);
 
@@ -744,7 +742,6 @@ impl DLEQProof {
         );
 
         let challenge = DLEQProof::get_challenge(&self.A, &self.B, &self.xA, &self.xB, &kA_, &kB_);
-        println!("got challenge: {:?} which should equal {:?}", challenge, self.challenge);
 
         return challenge == self.challenge;
 
@@ -789,7 +786,6 @@ mod tests {
         let mut rng = rand_new::thread_rng();
         let x = Fl::from_bigint(&rng.gen_biguint(512).to_bigint().unwrap());
         let proof = DLEQProof::new(x, point_A, point_B).unwrap();
-        println!("proof: {:?}", proof.verify());
         assert!(proof.verify());
     }
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,13 @@ pub type Fr = poseidon_rs::Fr; // alias
 
 use arrayref::array_ref;
 
-#[cfg(not(feature = "aarch64"))]
-use blake_hash::Digest; // compatible version with Blake used at circomlib
+// #[cfg(not(feature = "aarch64"))]
+// use blake_hash::Digest; // compatible version with Blake used at circomlib
 
-#[cfg(feature = "aarch64")]
-extern crate blake; // compatible version with Blake used at circomlib
-
+// #[cfg(feature = "aarch64")]
+// extern crate blake; // compatible version with Blake used at circomlib
+use blake2::{Blake2b512, Blake2s256, Digest};
+// use hex_literal::hex;
 use std::cmp::min;
 
 use num_bigint::{BigInt, RandBigInt, Sign, ToBigInt};
@@ -223,19 +224,29 @@ pub fn decompress_point(bb: [u8; 32]) -> Result<Point, String> {
     Ok(Point { x: x_fr, y: y_fr })
 }
 
-#[cfg(not(feature = "aarch64"))]
-fn blh(b: &[u8]) -> Vec<u8> {
-    let hash = blake_hash::Blake512::digest(b);
-    hash.to_vec()
-}
+// #[cfg(not(feature = "aarch64"))]
+// fn blh(b: &[u8]) -> Vec<u8> {
+//     println!("hashing {:?} {:?}", b.len(), b);
+//     let debugggggggggme = blake_hash::Blake512::digest(b);
+//     println!("debugging {:?}", debugggggggggme);
 
-#[cfg(feature = "aarch64")]
-fn blh(b: &[u8]) -> Vec<u8> {
-    let mut hash = [0; 64];
-    blake::hash(512, b, &mut hash).unwrap();
-    hash.to_vec()
-}
+//     let hash = blake_hash::Blake512::digest(b);
+//     hash.to_vec()
+// }
 
+// #[cfg(feature = "aarch64")]
+// fn blh(b: &[u8]) -> Vec<u8> {
+//     let mut hash = [0; 64];
+//     blake::hash(512, b, &mut hash).unwrap();
+//     hash.to_vec()
+// }
+
+fn blh(b: &[u8]) -> Vec<u8> {
+    let mut h = Blake2b512::new();
+    h.update(b);
+    let digest = h.finalize();
+    return digest[..].to_vec();
+}
 #[derive(Debug, Clone)]
 pub struct Signature {
     pub r_b8: Point,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,6 @@ pub fn decompress_point(bb: [u8; 32]) -> Result<Point, String> {
 // }
 
 pub fn blh(b: &[u8]) -> Vec<u8> {
-    println!("TODO: add test that this new blake512 function is giving correct output. Not doing so could have unlikely yet critical implications");
     let mut h = Blake2b512::new();
     h.update(b);
     let digest = h.finalize();
@@ -743,7 +742,6 @@ mod tests {
 
         // test signature & verification
         let msg = BigInt::from_bytes_le(Sign::Plus, &hex::decode("00010203040506070809").unwrap());
-        println!("msg {:?}", msg.to_string());
         let sig = sk.sign(msg.clone()).unwrap();
         assert_eq!(
             sig.r_b8.x.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,8 @@ lazy_static! {
         y: Fr::one()
     };
 
-    pub static ref ORDER: Fr = Fr::from_str(
-        "21888242871839275222246405745257275088614511777268538073601725287587578984328",
-    ).unwrap();
-
-    pub static ref ORDER_BI: BigInt = BigInt::parse_bytes(
+    // Order expressed as a bigint (it is larger than the r modulus of the Fr struct)
+    pub static ref ORDER: BigInt = BigInt::parse_bytes(
         b"21888242871839275222246405745257275088614511777268538073601725287587578984328",
         10,
     ).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use arrayref::array_ref;
 
 // #[cfg(feature = "aarch64")]
 // extern crate blake; // compatible version with Blake used at circomlib
-use blake2::{Blake2b512, Blake2s256, Digest};
+use blake2::{Blake2b512, Digest};
 // use hex_literal::hex;
 use std::cmp::min;
 
@@ -155,6 +155,13 @@ impl Point {
             x: self.x,
             y: self.y,
             z: Fr::one(),
+        }
+    }
+
+    pub fn inverse(&self) -> Point {
+        Point {
+            x: self.x.inverse().unwrap(),
+            y: self.y
         }
     }
 
@@ -382,6 +389,21 @@ impl PrivateKey {
         let s = k + &sk_scalar * &h;
         Ok((r, s))
     }
+
+    // pub fn encrypt_elgamal(&self, msg: Point) -> [Point; 2] {
+   
+    // }
+
+    pub fn decrypt_elgamal(&self, c1: Point, c2: Point) -> Point {
+        let shared_secret = c1.mul_scalar(&self.scalar_key());
+        let msg = c2.projective()
+                                    .add(
+                                        &shared_secret.inverse().projective()
+                                    )
+                                    .affine();
+        msg
+    }
+
 }
 
 pub fn schnorr_hash(pk: &Point, msg: BigInt, c: &Point) -> Result<BigInt, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,8 +300,8 @@ pub fn decompress_signature(b: &[u8; 64]) -> Result<Signature, String> {
 }
 
 pub struct ElGamalEncryption {
-    c1: Point,
-    c2: Point
+    pub c1: Point,
+    pub c2: Point
 }
 
 pub struct PrivateKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,7 +523,7 @@ pub fn decompress_signature(b: &[u8; 64]) -> Result<Signature, String> {
         Result::Ok(res) => Ok(Signature { r_b8: res, s: s.to_string() }),
     }
 }
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ElGamalEncryption {
     pub c1: Point,
     pub c2: Point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl Point {
         }
     }
 
-    pub fn inverse(&self) -> Point {
+    pub fn neg(&self) -> Point {
         let mut x_inverse = Fr::zero();
         x_inverse.sub_assign(&self.x);
         Point {
@@ -278,7 +278,6 @@ impl Point {
     // Converts a point to a message by dividing by 1024 (a.k.a. right-shifting by 10)
     pub fn to_msg(&self) -> Fr {
         let mut msg = self.x.clone().into_repr();
-        // println!("{:?}", self.x.into_repr().shr(10));
         msg.shr(10);
         Fr::from_repr(msg).unwrap()
 
@@ -507,7 +506,7 @@ impl PrivateKey {
         let shared_secret = encrypted_point.c1.mul_scalar(&self.scalar_key());
         // Subtract the shared secret
         encrypted_point.c2.projective().add(
-                &shared_secret.inverse().projective()
+                &shared_secret.neg().projective()
         ).affine()
     }
 
@@ -637,7 +636,7 @@ mod tests {
         // assert_eq!(some_point_x_inverse, some_point.x.inverse().unwrap());
         assert!(some_point.equals(
             some_point.projective().add(&another_point.projective()).add(
-            &another_point.inverse().projective())
+            &another_point.neg().projective())
             .affine()
         ));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -653,7 +653,11 @@ impl PrivateKey {
 
     pub fn decrypt_elgamal(&self, encrypted_point: ElGamalEncryption) -> Point {
         // Make sure inputs aren't bad (i imagine this check could be skipped for performance reasons, but it seems a sanity check here would be helpful)
-        assert!(encrypted_point.c1.on_curve() && encrypted_point.c2.on_curve());
+        assert!(encrypted_point.c1.on_curve(), "Error: C1 is not on the curve!");
+        assert!(encrypted_point.c1.in_subgroup(), "Error: C1 is not in the subgroup!");
+        assert!(encrypted_point.c2.on_curve(), "Error: C2 is not on the curve!");
+        assert!(encrypted_point.c2.in_subgroup(), "Error: C2 is not in the subgroup!");
+        
         let shared_secret = encrypted_point.c1.mul_scalar(&self.scalar_key());
         // Subtract the shared secret
         encrypted_point.c2.add(&shared_secret.neg())


### PR DESCRIPTION
I merged the changes mentioned in https://github.com/arnaucube/babyjubjub-rs/issues/7 for more `Point` functions, ElGamal encryption/decryption, DLEQ proofs, (unoptimized) serialization/deserialization, a new `Fl` struct, and a bug fix. 

Note: There is one planned change in that issue I did not make: preventing `mul_scalar` from accepting negative inputs. I imagine this is not unique to `mul_scalar`, so a better solution would be to replace all instances of `BigInt` to `BigUint` except when negative numbers are needed. There seem to be some places negative numbers are needed, and I wanted to be conservative by not changing them. Thus, refactoring `BigInt` usage to `BigUint` usage became a bit hairy and I opted not to make that change out of concern with potentially breaking some functionality.

